### PR TITLE
Update UA match regex to also match iOS 12

### DIFF
--- a/lib/public/script.js
+++ b/lib/public/script.js
@@ -75,7 +75,7 @@ function deepLink(options) {
     // chrome and safari on ios >= 9 don't allow the iframe approach
     if (
       ua.match(/CriOS/) ||
-      (ua.match(/Safari/) && ua.match(/Version\/(9|10|11)/))
+      (ua.match(/Safari/) && ua.match(/Version\/(9|10|11|12)/))
     ) {
       launchWekitApproach(urls.deepLink, urls.iosStoreLink || urls.fallback);
     } else {


### PR DESCRIPTION
Package was not matching iOS 12, which did a fallback to `launchIframeApproach` which doesn't work on iOS Safari.