### PR TITLE
Make the deeplink url configurable in the config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ _node-deeplink_ currently only supports Android and ios.
 
 Options to pass on to _node-deeplink_ are:
 
+- `url`: **mandatory**. The deeplink url you want the user to be directed to e.g. `app://account`.
 - `fallback`: **mandatory**. A fallback url in case the user is opening the link via an unsupported platform like desktop / windows phone etc. In such case, the fallback url will be opened in the user's browser like a normal link.
 - `android_package_name`: **optional**. In case you want to support Android deep links, pass your app's package name.
 - `ios_store_link`: **optional**. In case you want to support ios deep links, pass your app's itunes url. You can get it [here](https://linkmaker.itunes.apple.com/us/).
@@ -64,14 +65,12 @@ Options to pass on to _node-deeplink_ are:
 
 When a request comes in, the following query params a re checked:
 
-- `url`: **mandatory**. The deeplink url you want the user to be directed to e.g. `app://account`.
+- `url`: **optional**. If available, will prefer this deeplink url over the one from the options.
 - `fallback`: **optional**. If available, will prefer this fallback address over the one from the options.
 
 ### Behaviour
 
-_node-deeplink_ expects the request to contain a query param `url=...` so that the deeplink mechanism will work. If no such query is present then _node-deeplink_ ignores the request and calls `next()` so the request will be handled by the next middleware.
-
-_node-deeplink_ works by first sending the user to an html page with a user-agent sniffing script. After figuring out the user's device, it redirects the to the predefined deeplink. In practice, after clicking the link, the browser will be opened for a very short moment and then the redirect will happen.
+_node-deeplink_ works by first sending the user to an html page with a user-agent sniffing script. After figuring out the user's device, it redirects them to the predefined deeplink. In practice, after clicking the link, the browser will be opened for a very short moment and then the redirect will happen.
 
 ### TODO
 

--- a/lib/deeplink.js
+++ b/lib/deeplink.js
@@ -18,11 +18,9 @@ module.exports = function(options) {
       opts[k] = options[k];
     });
 
-    // bail out if we didn't get url
-    if (!req.query.url) {
-      return next();
+    if (req.query.url) {
+      opts.url = req.query.url;
     }
-    opts.url = req.query.url;
 
     if (req.query.fallback) {
       opts.fallback = req.query.fallback;

--- a/lib/deeplink.js
+++ b/lib/deeplink.js
@@ -22,6 +22,11 @@ module.exports = function(options) {
       opts.url = req.query.url;
     }
 
+    // bail out if we didn't get url
+    if (!opts.url) {
+      return next();
+    }
+
     if (req.query.fallback) {
       opts.fallback = req.query.fallback;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -981,9 +981,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.15",
+      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "lodash.sortby": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -982,7 +982,7 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "https://artifact.socrate.vsct.fr/artifactory/api/npm/all-npm/lodash/-/lodash-4.17.15.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },

--- a/test/lib/browser.js
+++ b/test/lib/browser.js
@@ -27,7 +27,7 @@ module.exports = function(ua) {
       }
     });
 
-    browser.visit('/?url=' + url, noop);
+    browser.visit(url ? `/?url=${url}` : '/', noop);
   };
 
   obj.close = () => {

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,24 @@ describe('android', () => {
     );
   });
 
+  it('should return intent on android device based on configured url', done => {
+    browser.go(
+      null,
+      {
+        fallback: fallback,
+        android_package_name: androidPackageName,
+        url: url
+      },
+      res => {
+        assert.equal(
+          res,
+          'intent://test/#Intent;scheme=app;package=ind.vandelay.art;end;'
+        );
+        done();
+      }
+    );
+  });
+
   it('should return the fallback url when no package name defined in android', done => {
     browser.go(
       url,
@@ -67,6 +85,21 @@ describe('ios', () => {
       {
         fallback: fallback,
         ios_store_link: iosStoreLink
+      },
+      res => {
+        assert.equal(res, url);
+        done();
+      }
+    );
+  });
+
+  it('should return deeplink url on ios device based on configured url', done => {
+    browser.go(
+      null,
+      {
+        fallback: fallback,
+        ios_store_link: iosStoreLink,
+        url: url
       },
       res => {
         assert.equal(res, url);
@@ -107,6 +140,22 @@ describe('general', () => {
         fallback: fallback,
         ios_store_link: iosStoreLink,
         android_package_name: androidPackageName
+      },
+      res => {
+        assert.equal(res, fallback);
+        done();
+      }
+    );
+  });
+
+  it('should use the configured url if none was provided in the query params', done => {
+    browser.go(
+      null,
+      {
+        fallback: fallback,
+        ios_store_link: iosStoreLink,
+        android_package_name: androidPackageName,
+        url: url
       },
       res => {
         assert.equal(res, fallback);


### PR DESCRIPTION
This PR aims at allowing a new `url` config option which can be used instead of the query param. The query param is still supported, and when provided it takes precedence over the config option.